### PR TITLE
Fix #136 Energizing Rod beam render

### DIFF
--- a/src/main/java/owmii/powah/client/render/tile/EnergizingRodRenderer.java
+++ b/src/main/java/owmii/powah/client/render/tile/EnergizingRodRenderer.java
@@ -60,7 +60,8 @@ public class EnergizingRodRenderer extends AbstractTileRenderer<EnergizingRodTil
             Vector3d vec3d2 = pos.subtract(orbPos);
             double d0 = vec3d2.length();
             vec3d2 = vec3d2.normalize();
-            float f5 = (float) Math.acos(vec3d2.y);
+            // Normalize sometimes gives vector with length > 1, which breaks acos if the y component is < -1 or > 1
+            float f5 = (float) Math.acos(MathHelper.clamp(vec3d2.y, -1.0, 1.0));
             float f6 = (float) MathHelper.atan2(vec3d2.z, vec3d2.x);
 
             matrix.rotate(Vector3f.YP.rotationDegrees((((float) Math.PI / 2F) - f6) * (180F / (float) Math.PI)));


### PR DESCRIPTION
Fix #136 by clamping the y component of the normalized vector between -1.0 and 1.0 for `acos`.
The reason why this is needed is normalize sometimes results in a vector of length > 1 due to the nature of  floating point arithmetic, but also not help that the normalize implementation casts sqrt to a float then back to a double.
Which when along the y axis breaks acos because it expects a number `[-1.0,1.0]`.

![Fixed Energizing Beams top-down](https://user-images.githubusercontent.com/630920/108226316-c24ff900-7177-11eb-89ac-106e7cf1f853.png)
![Fixed Energizing Beams all around](https://user-images.githubusercontent.com/630920/108227163-9123f880-7178-11eb-8faf-2cb7eb782568.png)
