### PR TITLE
Fix #117 Energy Dupe

### DIFF
--- a/src/main/java/owmii/powah/block/energycell/EnergyCellTile.java
+++ b/src/main/java/owmii/powah/block/energycell/EnergyCellTile.java
@@ -38,7 +38,7 @@ public class EnergyCellTile extends AbstractEnergyStorage<Tier, EnergyCellConfig
 
     @Override
     public long extractEnergy(int maxExtract, boolean simulate, @Nullable Direction side) {
-        return super.extractEnergy(maxExtract, isCreative(), side);
+        return super.extractEnergy(maxExtract, simulate || isCreative(), side);
     }
 
     @Override


### PR DESCRIPTION
What was happening was `maxReceive` was always being used for pushEnergy, this was changed to use the remaining energy instead.

Changs in PR:
- Fix #117 by making cables only push the remainder amount
- Fix not simulating for EnergyCell extract.
