### PR TITLE
Fix #150 CME in client setup event

### DIFF
--- a/src/main/java/owmii/powah/client/Client.java
+++ b/src/main/java/owmii/powah/client/Client.java
@@ -12,8 +12,12 @@ public enum Client implements IClient {
 
     @Override
     public void client(FMLClientSetupEvent event) {
-        TileRenderer.register();
         EntityRenderer.register();
+    }
+
+    @Override
+    public void syncClient(FMLClientSetupEvent event) {
+        TileRenderer.register();
         Screens.register();
         ItemModelProperties.register();
         PowahBook.register();


### PR DESCRIPTION
Depends on https://github.com/owmii/Lollipop/pull/13

Fix #150 by using `event.enqueueWork` for things that are not thread safe.
Was happening because the `FMLClientSetupEvent` is run in parallel so it's unsafe to call methods that for example insert into a `HashMap`.

~~Not sure if you wanted to add something to Lollipop to generalize this fix but this should be okay for now.~~
Made a PR to Lollipop to add in a method for synchronous setup.
Will make a similar PR to LostTrinkets.

Hope I'm not bothering too much with these PRs. Feel free to take your time with releases, no rush okay?
Want you to be well. ❤️ 