### PR TITLE
Fix #130 Ender Channels 2-12 being the same

### DIFF
--- a/src/main/java/owmii/powah/block/ender/AbstractEnderTile.java
+++ b/src/main/java/owmii/powah/block/ender/AbstractEnderTile.java
@@ -154,7 +154,7 @@ public class AbstractEnderTile<V extends Enum<V> & IVariant<V>, C extends IEnerg
             return this.energy;
         } else {
             return Server.getData(EnderNetwork::new)
-                    .getChannels(this).get(this.channel.get()).setTransfer(getEnergyTransfer());
+                    .getEnergy(this, this.channel.get()).setTransfer(getEnergyTransfer());
         }
     }
 


### PR DESCRIPTION
Fix #130 by switching away from `NonNullList` which doesn't use a supplier to create new instances of `Energy`, it copies by reference which resulted in 2-12 sharing the same instance, to using an `ImmutableList` populated with seperate instances of `Energy`.
