### PR TITLE
Fix #81 by checking for air or unregistered block

### DIFF
--- a/src/main/java/owmii/powah/api/PowahAPI.java
+++ b/src/main/java/owmii/powah/api/PowahAPI.java
@@ -1,9 +1,11 @@
 package owmii.powah.api;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.util.IItemProvider;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.registries.ForgeRegistries;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.HashMap;
@@ -72,6 +74,9 @@ public class PowahAPI {
      * @param heat:  the heat of the block.
      **/
     public static void registerHeatSource(Block block, int heat) {
+        if (block == Blocks.AIR || !ForgeRegistries.BLOCKS.containsKey(block.getRegistryName())) {
+            throw new IllegalArgumentException(block + " is air or unregistered");
+        }
         HEAT_SOURCES.put(block, heat);
     }
 

--- a/src/main/java/owmii/powah/client/compat/jei/HeatSourceCategory.java
+++ b/src/main/java/owmii/powah/client/compat/jei/HeatSourceCategory.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class HeatSourceCategory implements IRecipeCategory<HeatSourceCategory.Recipe> {
     public static final ResourceLocation GUI_BACK = new ResourceLocation(Powah.MOD_ID, "textures/gui/jei/misc.png");
@@ -100,6 +101,9 @@ public class HeatSourceCategory implements IRecipeCategory<HeatSourceCategory.Re
         public static List<Recipe> getBucketRecipes(IIngredientManager ingredientManager) {
             Collection<ItemStack> allItemStacks = ingredientManager.getAllIngredients(VanillaTypes.ITEM);
             List<Recipe> recipes = new ArrayList<>();
+            Powah.LOGGER.debug("HEAT SOURCE RECIPE ALL: [" + PowahAPI.HEAT_SOURCES.entrySet().stream()
+                    .map(e -> e.getKey() + " -> " + e.getValue())
+                    .collect(Collectors.joining(", ")) + "]");
             allItemStacks.forEach(stack -> {
                 if (stack.getItem() instanceof BlockItem) {
                     BlockItem item = (BlockItem) stack.getItem();
@@ -140,6 +144,7 @@ public class HeatSourceCategory implements IRecipeCategory<HeatSourceCategory.Re
             }
             this.block = block;
             this.heat = heat;
+            Powah.LOGGER.debug("HEAT SOURCE RECIPE INIT: " + this);
         }
 
         @Nullable
@@ -153,6 +158,11 @@ public class HeatSourceCategory implements IRecipeCategory<HeatSourceCategory.Re
 
         public int getHeat() {
             return this.heat;
+        }
+
+        @Override
+        public String toString() {
+            return "HeatSourceRecipe{" + block.getRegistryName() + (fluid != null ? " (fluid " + fluid.getRegistryName() + ")" : "") + " -> " + heat + "}";
         }
     }
 }

--- a/src/main/java/owmii/powah/config/ConfigHandler.java
+++ b/src/main/java/owmii/powah/config/ConfigHandler.java
@@ -1,6 +1,7 @@
 package owmii.powah.config;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.ModList;
@@ -71,7 +72,7 @@ public class ConfigHandler {
                     if (ModList.get().isLoaded(rl.getNamespace().toLowerCase())) {
                         try {
                             Block block = ForgeRegistries.BLOCKS.getValue(rl);
-                            if (block != null) {
+                            if (block != null && block != Blocks.AIR && ForgeRegistries.BLOCKS.containsKey(rl)) {
                                 try {
                                     int heat = Integer.parseInt(args[1]);
                                     if (heat > 0 && heat < 900000000) {
@@ -83,7 +84,7 @@ public class ConfigHandler {
                                     LOGGER.fatal(MARKER, "Ignored block: {}, for incorrect args: {}", regName, args[1]);
                                     e.printStackTrace();
                                 }
-                            } else LOGGER.fatal(MARKER, "Ignored Wrong block registry name {}.", regName);
+                            } else LOGGER.fatal(MARKER, "Ignored air or unregistered block registry name {}.", regName);
                         } catch (Exception e) {
                             LOGGER.fatal(MARKER, "Ignored Wrong block registry name {}.", regName);
                             e.printStackTrace();


### PR DESCRIPTION
Fix #81 by adding a check for air or unregistered block.

```py
[21Feb2021 13:27:33.651] [Worker-Main-14/INFO] [powah/Config]: Added block: minecraft:lava, with heat of: 1000
[21Feb2021 13:27:33.651] [Worker-Main-14/INFO] [powah/Config]: Added block: minecraft:magma_block, with heat of: 1200
[21Feb2021 13:27:33.651] [Worker-Main-14/INFO] [powah/Config]: Added block: minecraft:fire_coral, with heat of: 1800
[21Feb2021 13:27:33.651] [Worker-Main-14/INFO] [powah/Config]: Added block: powah:nitro_crystal_block, with heat of: 8000
[21Feb2021 13:27:33.652] [Worker-Main-14/INFO] [powah/Config]: Added block: powah:blazing_crystal_block, with heat of: 2800
[21Feb2021 13:27:33.652] [Worker-Main-14/INFO] [powah/Config]: Added block: botania:blaze_block, with heat of: 1600
[21Feb2021 13:27:33.652] [Worker-Main-14/FATAL] [powah/Config]: Ignored air or unregistered block registry name botania:blaze_lantern.
[21Feb2021 13:27:33.652] [Worker-Main-14/INFO] [powah/Config]: Added block: quark:brimstone, with heat of: 1200
[21Feb2021 13:27:33.652] [Worker-Main-14/INFO] [powah/Config]: Added fluid: minecraft:lava, with heat of: 10000 per 100 mb
```