### PR TITLE
Add Battery to curio tag

### DIFF
--- a/src/generated/resources/.cache/cache
+++ b/src/generated/resources/.cache/cache
@@ -1,3 +1,4 @@
+c8e8fff0641f6578a367e9afd9fc533d4f844eed data/curios/tags/items/curio.json
 6dc78c874fe1bc3f2dbbbe213acaa37ce343a89a data/forge/tags/blocks/ices.json
 c271ce7ac008a2fa0b5c186ca91653613707df7d data/forge/tags/blocks/ices/blue.json
 098c0402df03cb82a4ea3ad788bb5f6fe8bbc32e data/forge/tags/blocks/ices/dry.json

--- a/src/generated/resources/data/curios/tags/items/curio.json
+++ b/src/generated/resources/data/curios/tags/items/curio.json
@@ -1,0 +1,12 @@
+{
+  "replace": false,
+  "values": [
+    "powah:battery_starter",
+    "powah:battery_basic",
+    "powah:battery_hardened",
+    "powah:battery_blazing",
+    "powah:battery_niotic",
+    "powah:battery_spirited",
+    "powah:battery_nitro"
+  ]
+}

--- a/src/main/java/owmii/powah/compat/curios/CurioTagsProvider.java
+++ b/src/main/java/owmii/powah/compat/curios/CurioTagsProvider.java
@@ -1,0 +1,38 @@
+package owmii.powah.compat.curios;
+
+import net.minecraft.data.BlockTagsProvider;
+import net.minecraft.data.DataGenerator;
+import net.minecraft.data.ItemTagsProvider;
+import net.minecraft.item.Item;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.Tags;
+import net.minecraftforge.common.data.ExistingFileHelper;
+import owmii.powah.item.Itms;
+import top.theillusivec4.curios.api.CuriosApi;
+
+import javax.annotation.Nullable;
+
+public class CurioTagsProvider extends ItemTagsProvider {
+    public CurioTagsProvider(DataGenerator dataGenerator, BlockTagsProvider blockTagsProvider, String modId, @Nullable ExistingFileHelper existingFileHelper) {
+        super(dataGenerator, blockTagsProvider, modId, existingFileHelper);
+    }
+
+    @Override
+    protected void registerTags() {
+        getOrCreateBuilder(CurioTags.CURIO).add(Itms.BATTERY.getAll().toArray(new Item[0]));
+    }
+
+    public static class CurioTags {
+        public static final Tags.IOptionalNamedTag<Item> CURIO = tag("curio");
+
+        /**
+         * We have to use the curios namespace.
+         *
+         * @see <a href="https://github.com/TheIllusiveC4/Curios/wiki/How-to-Use:-Developers#marking-items-with-curio-types">Marking Items with Curio Types</a>
+         */
+        private static Tags.IOptionalNamedTag<Item> tag(String name) {
+            return ItemTags.createOptional(new ResourceLocation(CuriosApi.MODID, name));
+        }
+    }
+}

--- a/src/main/java/owmii/powah/compat/curios/package-info.java
+++ b/src/main/java/owmii/powah/compat/curios/package-info.java
@@ -1,0 +1,4 @@
+@NonnullDefault
+package owmii.powah.compat.curios;
+
+import org.lwjgl.system.NonnullDefault;

--- a/src/main/java/owmii/powah/compat/package-info.java
+++ b/src/main/java/owmii/powah/compat/package-info.java
@@ -1,0 +1,4 @@
+@NonnullDefault
+package owmii.powah.compat;
+
+import org.lwjgl.system.NonnullDefault;

--- a/src/main/java/owmii/powah/handler/event/DataEvents.java
+++ b/src/main/java/owmii/powah/handler/event/DataEvents.java
@@ -5,6 +5,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.GatherDataEvent;
 import owmii.powah.Powah;
+import owmii.powah.compat.curios.CurioTagsProvider;
 
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
 public class DataEvents {
@@ -14,5 +15,6 @@ public class DataEvents {
         TagsProvider.Blocks bp = new TagsProvider.Blocks(generator, Powah.MOD_ID, event.getExistingFileHelper());
         generator.addProvider(bp);
         generator.addProvider(new TagsProvider.Items(generator, bp, Powah.MOD_ID, event.getExistingFileHelper()));
+        generator.addProvider(new CurioTagsProvider(generator, bp, Powah.MOD_ID, event.getExistingFileHelper()));
     }
 }


### PR DESCRIPTION
Closes #92.

Tagging the battery as `curio` seems that `inventoryTick` gets called properly for us!
Also added a datagen for it. I'm not sure if the tags should go in Lollipop or not, but I figured that because Curios' Tags are generated dynamically it'd make more sense to just keep it contained in Powah.

[Video](https://www.youtube.com/watch?v=Aay_Pvx1mHI) (33s) showing it in action.

Let me know if you'd rather it go in only specific curio slots rather than any curio slot.

On an unrelated note:
Would it be okay if I made some PRs to update the mappings and forge to 1.16.5? I have a WIP branch for it and it just has some name changes afaict. It should still be compatible with 1.16.4 since very little changed in the update to 1.16.5. Although for the Krate mod I think the latest code needs to be pushed from your local repo for it.
