### PR TITLE
Energizing Orb rotation and  Energizing Rod beam colour

### DIFF
--- a/src/main/java/owmii/powah/block/Tier.java
+++ b/src/main/java/owmii/powah/block/Tier.java
@@ -3,7 +3,20 @@ package owmii.powah.block;
 import owmii.lib.registry.IVariant;
 
 public enum Tier implements IVariant<Tier> {
-    STARTER, BASIC, HARDENED, BLAZING, NIOTIC, SPIRITED, NITRO, CREATIVE;
+    STARTER(0xA7A7A7),
+    BASIC(0xA3AB9F),
+    HARDENED(0xBBA993),
+    BLAZING(0xE4B040),
+    NIOTIC(0x13EED2),
+    SPIRITED(0xAFE241),
+    NITRO(0xD7746C),
+    CREATIVE(0x8D29AD);
+
+    private final int color;
+
+    Tier(int color) {
+        this.color = color;
+    }
 
     @Override
     public Tier[] getVariants() {
@@ -12,5 +25,9 @@ public enum Tier implements IVariant<Tier> {
 
     public static Tier[] getNormalVariants() {
         return new Tier[]{STARTER, BASIC, HARDENED, BLAZING, NIOTIC, SPIRITED, NITRO};
+    }
+
+    public int getColor() {
+        return color;
     }
 }

--- a/src/main/java/owmii/powah/block/energizing/EnergizingOrbBlock.java
+++ b/src/main/java/owmii/powah/block/energizing/EnergizingOrbBlock.java
@@ -148,7 +148,7 @@ public class EnergizingOrbBlock extends AbstractBlock<IVariant.Single, Energizin
     public void search(World worldIn, BlockPos pos) {
         int range = Configs.ENERGIZING.range.get();
         List<BlockPos> list = BlockPos.getAllInBox(pos.add(-range, -range, -range), pos.add(range, range, range)).map(BlockPos::toImmutable).filter(pos1 -> !pos.equals(pos1)).collect(Collectors.toList());
-        list.forEach(pos1 -> {
+        list.stream().filter(p -> worldIn.isBlockPresent(pos)).forEach(pos1 -> {
             TileEntity tileEntity1 = worldIn.getTileEntity(pos1);
             if (tileEntity1 instanceof EnergizingRodTile) {
                 if (!((EnergizingRodTile) tileEntity1).hasOrb()) {

--- a/src/main/java/owmii/powah/block/energizing/EnergizingOrbBlock.java
+++ b/src/main/java/owmii/powah/block/energizing/EnergizingOrbBlock.java
@@ -11,6 +11,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.NBTUtil;
+import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Direction;
@@ -18,8 +19,6 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.math.shapes.IBooleanFunction;
-import net.minecraft.util.math.shapes.ISelectionContext;
-import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.TranslationTextComponent;
@@ -47,22 +46,22 @@ import java.util.stream.Collectors;
 import static net.minecraft.util.math.shapes.VoxelShapes.combineAndSimplify;
 
 public class EnergizingOrbBlock extends AbstractBlock<IVariant.Single, EnergizingOrbBlock> implements IWaterLoggable, IWrenchable, IHud {
-    private static final VoxelShape SHAPE = combineAndSimplify(makeCuboidShape(3.5D, 5.0D, 3.5D, 12.5D, 14.23D, 12.5D), makeCuboidShape(2.5D, 0.0D, 2.5D, 13.5D, 1.0D, 13.5D), IBooleanFunction.OR);
 
     public EnergizingOrbBlock(Properties properties) {
         super(properties);
-        setDefaultState();
+        setStateProps(state -> state.with(BlockStateProperties.FACING, Direction.DOWN));
+        this.shapes.put(Direction.UP, combineAndSimplify(makeCuboidShape(3.5D, 11.0D, 3.5D, 12.5D, 1.77D, 12.5D), makeCuboidShape(2.5D, 15.0D, 2.5D, 13.5D, 16.0D, 13.5D), IBooleanFunction.OR));
+        this.shapes.put(Direction.DOWN, combineAndSimplify(makeCuboidShape(3.5D, 14.23D, 3.5D, 12.5D, 5.0D, 12.5D), makeCuboidShape(2.5D, 0.0D, 2.5D, 13.5D, 1.0D, 13.5D), IBooleanFunction.OR));
+        this.shapes.put(Direction.NORTH, combineAndSimplify(makeCuboidShape(3.5D, 3.5D, 14.23D, 12.5D, 12.5D, 5.0D), makeCuboidShape(2.5D, 2.5D, 0.0D, 13.5D, 13.5D, 1.0D), IBooleanFunction.OR));
+        this.shapes.put(Direction.SOUTH, combineAndSimplify(makeCuboidShape(3.5D, 3.5D, 11.0D, 12.5D, 12.5D, 1.77D), makeCuboidShape(2.5D, 2.5D, 15.0D, 13.5D, 13.5D, 16.0D), IBooleanFunction.OR));
+        this.shapes.put(Direction.WEST, combineAndSimplify(makeCuboidShape(14.23D, 3.5D, 3.5D, 5.0D, 12.5D, 12.5D), makeCuboidShape(0.0D, 2.5D, 2.5D, 1.0D, 13.5D, 13.5D), IBooleanFunction.OR));
+        this.shapes.put(Direction.EAST, combineAndSimplify(makeCuboidShape(11.0D, 3.5D, 3.5D, 1.77D, 12.5D, 12.5D), makeCuboidShape(15.0D, 2.5D, 2.5D, 16.0D, 13.5D, 13.5D), IBooleanFunction.OR));
     }
 
     @Nullable
     @Override
     public TileEntity createTileEntity(BlockState state, IBlockReader world) {
         return new EnergizingOrbTile();
-    }
-
-    @Override
-    public VoxelShape getShape(BlockState state, IBlockReader worldIn, BlockPos pos, ISelectionContext context) {
-        return SHAPE;
     }
 
     @Override
@@ -98,6 +97,11 @@ public class EnergizingOrbBlock extends AbstractBlock<IVariant.Single, Energizin
     @Override
     public void onBlockAdded(BlockState state, World worldIn, BlockPos pos, BlockState oldState, boolean isMoving) {
         search(worldIn, pos);
+    }
+
+    @Override
+    protected Facing getFacing() {
+        return Facing.ALL;
     }
 
     @Override

--- a/src/main/java/owmii/powah/block/energizing/EnergizingOrbTile.java
+++ b/src/main/java/owmii/powah/block/energizing/EnergizingOrbTile.java
@@ -1,7 +1,11 @@
 package owmii.powah.block.energizing;
 
+import net.minecraft.block.BlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.state.properties.BlockStateProperties;
+import net.minecraft.util.Direction;
+import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.world.World;
 import net.minecraftforge.items.wrapper.RecipeWrapper;
 import owmii.lib.block.AbstractTickableTile;
@@ -39,6 +43,22 @@ public class EnergizingOrbTile extends AbstractTickableTile<IVariant.Single, Ene
         this.buffer.write(nbt, "buffer", true, false);
         nbt.putBoolean("contain_recipe", this.containRecipe);
         return super.writeSync(nbt);
+    }
+
+    public Direction getOrbUp() {
+        if (this.world != null) {
+            BlockState state = this.getBlockState();
+            if (state.hasProperty(BlockStateProperties.FACING)) {
+                return state.get(BlockStateProperties.FACING).getOpposite();
+            }
+        }
+        return Direction.UP;
+    }
+
+    public Vector3d getOrbCenter() {
+        Direction up = getOrbUp();
+        double scale = 0.1;
+        return Vector3d.copyCentered(this.pos).add(up.getXOffset() * scale, up.getYOffset() * scale, up.getZOffset() * scale);
     }
 
     @Nullable

--- a/src/main/java/owmii/powah/block/energizing/EnergizingRodTile.java
+++ b/src/main/java/owmii/powah/block/energizing/EnergizingRodTile.java
@@ -44,32 +44,38 @@ public class EnergizingRodTile extends AbstractEnergyStorage<Tier, EnergizingCon
     @Override
     protected int postTick(World world) {
         boolean flag = false;
-        if (!this.orbPos.equals(BlockPos.ZERO)) {
-            TileEntity tileEntity = world.getTileEntity(this.orbPos);
-            if (tileEntity instanceof EnergizingOrbTile) {
-                EnergizingOrbTile orb = (EnergizingOrbTile) tileEntity;
+        EnergizingOrbTile orb = getOrbTile();
+        if (orb != null) {
+            if (orb.containRecipe() && this.energy.hasEnergy()) {
+                this.coolDown.onward();
+                flag = true;
+            } else if (this.coolDown.getTicks() > 0) {
+                this.coolDown.back();
+                flag = true;
+            }
 
-                if (orb.containRecipe() && this.energy.hasEnergy()) {
-                    this.coolDown.onward();
-                    flag = true;
-                } else if (this.coolDown.getTicks() > 0) {
-                    this.coolDown.back();
-                    flag = true;
-                }
-
-                if (this.coolDown.ended()) {
-                    long fill = Math.min(this.energy.getEnergyStored(), getBlock().getConfig().getTransfer(getVariant()));
-                    this.energy.consume(orb.fillEnergy(fill));
-                    flag = true;
-                }
+            if (this.coolDown.ended()) {
+                long fill = Math.min(this.energy.getEnergyStored(), getBlock().getConfig().getTransfer(getVariant()));
+                this.energy.consume(orb.fillEnergy(fill));
+                flag = true;
             }
         }
         return flag ? 10 : -1;
     }
 
+    @Nullable
+    public EnergizingOrbTile getOrbTile() {
+        if (this.world != null && this.orbPos != BlockPos.ZERO && world.isBlockPresent(this.orbPos)) {
+            TileEntity tile = this.world.getTileEntity(this.orbPos);
+            if (tile instanceof EnergizingOrbTile) {
+                return (EnergizingOrbTile) tile;
+            }
+        }
+        return null;
+    }
+
     public boolean hasOrb() {
-        if (this.world == null) return false;
-        return this.orbPos != BlockPos.ZERO && this.world.getTileEntity(this.orbPos) instanceof EnergizingOrbTile;
+        return getOrbTile() != null;
     }
 
     public BlockPos getOrbPos() {

--- a/src/main/java/owmii/powah/client/render/tile/EnergizingOrbRenderer.java
+++ b/src/main/java/owmii/powah/client/render/tile/EnergizingOrbRenderer.java
@@ -1,7 +1,6 @@
 package owmii.powah.client.render.tile;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
-import net.minecraft.block.BlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.player.ClientPlayerEntity;
 import net.minecraft.client.renderer.IRenderTypeBuffer;
@@ -9,7 +8,6 @@ import net.minecraft.client.renderer.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.item.ItemStack;
-import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.util.math.vector.Vector3f;
 import owmii.lib.client.renderer.tile.AbstractTileRenderer;
@@ -65,10 +63,7 @@ public class EnergizingOrbRenderer extends AbstractTileRenderer<EnergizingOrbTil
 
         matrix.push();
         matrix.translate(0.5D, 0.5D, 0.5D);
-        BlockState blockState = te.getBlockState();
-        if (blockState.hasProperty(BlockStateProperties.FACING)) {
-            matrix.rotate(blockState.get(BlockStateProperties.FACING).getOpposite().getRotation());
-        }
+        matrix.rotate(te.getOrbUp().getRotation());
         matrix.translate(0.0D, 0.1D, 0.0D);
         matrix.scale(1.8F, 1.8F, 1.8F);
         MODEL.render(te, this, matrix, rtb, light, ov);

--- a/src/main/java/owmii/powah/client/render/tile/EnergizingOrbRenderer.java
+++ b/src/main/java/owmii/powah/client/render/tile/EnergizingOrbRenderer.java
@@ -1,6 +1,7 @@
 package owmii.powah.client.render.tile;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.block.BlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.player.ClientPlayerEntity;
 import net.minecraft.client.renderer.IRenderTypeBuffer;
@@ -8,6 +9,7 @@ import net.minecraft.client.renderer.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.item.ItemStack;
+import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.util.math.vector.Vector3f;
 import owmii.lib.client.renderer.tile.AbstractTileRenderer;
@@ -62,7 +64,12 @@ public class EnergizingOrbRenderer extends AbstractTileRenderer<EnergizingOrbTil
         }
 
         matrix.push();
-        matrix.translate(0.5D, 0.6D, 0.5D);
+        matrix.translate(0.5D, 0.5D, 0.5D);
+        BlockState blockState = te.getBlockState();
+        if (blockState.hasProperty(BlockStateProperties.FACING)) {
+            matrix.rotate(blockState.get(BlockStateProperties.FACING).getOpposite().getRotation());
+        }
+        matrix.translate(0.0D, 0.1D, 0.0D);
         matrix.scale(1.8F, 1.8F, 1.8F);
         MODEL.render(te, this, matrix, rtb, light, ov);
         matrix.pop();

--- a/src/main/java/owmii/powah/client/render/tile/EnergizingRodRenderer.java
+++ b/src/main/java/owmii/powah/client/render/tile/EnergizingRodRenderer.java
@@ -22,6 +22,7 @@ import owmii.lib.client.util.RenderTypes;
 import owmii.lib.util.math.V3d;
 import owmii.powah.Powah;
 import owmii.powah.api.wrench.IWrench;
+import owmii.powah.block.energizing.EnergizingOrbTile;
 import owmii.powah.block.energizing.EnergizingRodTile;
 
 public class EnergizingRodRenderer extends AbstractTileRenderer<EnergizingRodTile> {
@@ -48,13 +49,14 @@ public class EnergizingRodRenderer extends AbstractTileRenderer<EnergizingRodTil
             }
         }
 
-        if (te.hasOrb() && te.coolDown.ended() || te.hasOrb() && flag) {
+        EnergizingOrbTile orb = te.getOrbTile();
+        if (orb != null && (te.coolDown.ended() || flag)) {
 
             matrix.push();
             matrix.translate(0.5D, 0.5D, 0.5D);
 
-            V3d pos = V3d.from(te.getPos());
-            V3d orbPos = V3d.from(te.getOrbPos()).up(0.1D);
+            V3d pos = V3d.from(te.getPos()).center();
+            V3d orbPos = V3d.from(orb.getOrbCenter());
             float f2 = 1.0F;
             float f3 = f2 * 0.5F % 1.0F;
             Vector3d vec3d2 = pos.subtract(orbPos);

--- a/src/main/java/owmii/powah/client/render/tile/EnergizingRodRenderer.java
+++ b/src/main/java/owmii/powah/client/render/tile/EnergizingRodRenderer.java
@@ -88,15 +88,20 @@ public class EnergizingRodRenderer extends AbstractTileRenderer<EnergizingRodTil
             Matrix4f matrix4f = last.getMatrix();
             Matrix3f matrix3f = last.getNormal();
 
-            pos(builder, matrix4f, matrix3f, d12, 0.0F, d13, 255, 255, 255, 1, d23);
-            pos(builder, matrix4f, matrix3f, d12, (float) -d0, d13, 255, 255, 255, 1, d22);
-            pos(builder, matrix4f, matrix3f, d14, (float) -d0, d15, 255, 255, 255, 0.0F, d22);
-            pos(builder, matrix4f, matrix3f, d14, 0.0F, d15, 255, 255, 255, 0.0F, d23);
+            int color = te.getVariant().getColor();
+            int r = 0xFF & (color >> 16);
+            int g = 0xFF & (color >> 8);
+            int b = 0xFF & color;
 
-            pos(builder, matrix4f, matrix3f, d16, 0.0F, d17, 255, 255, 255, 1, d23);
-            pos(builder, matrix4f, matrix3f, d16, (float) -d0, d17, 255, 255, 255, 1, d22);
-            pos(builder, matrix4f, matrix3f, d18, (float) -d0, d19, 255, 255, 255, 0.0F, d22);
-            pos(builder, matrix4f, matrix3f, d18, 0.0F, d19, 255, 255, 255, 0.0F, d23);
+            pos(builder, matrix4f, matrix3f, d12, 0.0F, d13, r, g, b, 1, d23);
+            pos(builder, matrix4f, matrix3f, d12, (float) -d0, d13, r, g, b, 1, d22);
+            pos(builder, matrix4f, matrix3f, d14, (float) -d0, d15, r, g, b, 0.0F, d22);
+            pos(builder, matrix4f, matrix3f, d14, 0.0F, d15, r, g, b, 0.0F, d23);
+
+            pos(builder, matrix4f, matrix3f, d16, 0.0F, d17, r, g, b, 1, d23);
+            pos(builder, matrix4f, matrix3f, d16, (float) -d0, d17, r, g, b, 1, d22);
+            pos(builder, matrix4f, matrix3f, d18, (float) -d0, d19, r, g, b, 0.0F, d22);
+            pos(builder, matrix4f, matrix3f, d18, 0.0F, d19, r, g, b, 0.0F, d23);
 
             matrix.pop();
         }

--- a/src/main/resources/assets/powah/blockstates/energizing_orb.json
+++ b/src/main/resources/assets/powah/blockstates/energizing_orb.json
@@ -1,5 +1,10 @@
 {
   "variants": {
-	"": {"model": "powah:block/energizing_orb"}
+    "facing=up": {"model": "powah:block/energizing_orb", "x": 180},
+    "facing=down": {"model": "powah:block/energizing_orb"},
+    "facing=south": {"model": "powah:block/energizing_orb", "x": 90},
+    "facing=north": {"model": "powah:block/energizing_orb", "x": 90, "y": 180},
+    "facing=east": {"model": "powah:block/energizing_orb", "x": 90, "y": 270},
+    "facing=west": {"model": "powah:block/energizing_orb", "x": 90, "y": 90}
   }
 }


### PR DESCRIPTION
Depends optionally on https://github.com/owmii/Lollipop/pull/17

Closes https://github.com/owmii/Powah/issues/21

Partially addresses https://github.com/owmii/Powah/issues/88

I based the beam colours on the Energizing Rod Gems, but I think you'll probably want to adjust the colours to your liking.

This PR allows the Energizing Orb to be placed in all 6 directions and adds colour to the Energizing Rod Beams (which depends on the Lollipop PR but is optional, it just doesn't have colour without it).

Also needed to make the beam from the rod to the orb respect the different rotations of the orb (since it is slightly upwards).

Also changed places that retrieved the tile entity of the orb from the rod to be consistent and also check if the block is present (chunk is loaded) before retrieving it, except for linking with the wrench which will force-load temporarily like currently.

Also tested loading an existing world from before this PR and it properly defaults the orb to be facing "down" which is really upwards. I used the energizing rods for reference which also used the facing in the same way and because the code for placement was common I decided to follow the same convention.

**Screenshots**

![Energizing Orbs with different rotations](https://user-images.githubusercontent.com/630920/110237611-dd907600-7f77-11eb-8c24-6abcdf9e48be.png)

![Beams connecting to Orbs with different rotations](https://user-images.githubusercontent.com/630920/110237617-e4b78400-7f77-11eb-8878-7d299d7ca1e3.png)

![Energizing Rod beams with colours matching tier](https://user-images.githubusercontent.com/630920/110237626-f00aaf80-7f77-11eb-82b6-ce1de98f1415.png)
